### PR TITLE
fix [TypeError: Cannot call method 'split' of undefined] when real_name is undefined 

### DIFF
--- a/lib/passport-yandex/strategy.js
+++ b/lib/passport-yandex/strategy.js
@@ -93,8 +93,12 @@ Strategy.prototype.userProfile = function(accessToken, done) {
       profile.id = json.id;
       profile.username = json.display_name;
       profile.displayName = json.display_name;
-      profile.name = { familyName: json.real_name.split(' ')[0],
-                       givenName: json.real_name.split(' ')[1] };
+      if (json.real_name) {
+        var tokens = json.real_name.split(' ', 2);
+        profile.name = {familyName: tokens[0], givenName: tokens[1]};
+      } else {
+        profile.name = {};
+      }
       profile.gender = json.sex;
       profile.emails = [{ value: json.default_email }];
 


### PR DESCRIPTION
поле "real_name" иногда отстутствует в ответе login.yandex.ru/info
перед тем, как его парсить, добавил проверку, что поле в наличии

```
TypeError: Cannot call method 'split' of undefined
    at Strategy.userProfile (xxx/node_modules/passport-yandex/lib/passport-yandex/strategy.js:96:51)
```
